### PR TITLE
Verbesserung CSS: Mitteilungen im Dark-Mode

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -189,6 +189,19 @@
     @extend .message-warning;
     color: black;
   }
+  
+  .list-group-item-danger {
+    color: #fff !important;
+  }
+  
+  .list-group-item-warning {
+    color: #212529 !important;
+  }
+  
+  .list-group-item-success {
+    color: #fff !important;
+  }
+
 }
 
 .dashboard-lesson {


### PR DESCRIPTION
Vorher:
![Vorher](https://user-images.githubusercontent.com/74987472/129357504-d58f96c6-975c-48fa-976c-ea8978ea760d.png)
Nachher:
![Nachher](https://user-images.githubusercontent.com/74987472/129357502-ea9264fa-b2a4-45b3-bcc6-055d721fbb3c.png)

Eigentlich fehlt im Original nur das `!important`. Dies ist jetzt hier ergänzt.