### PR TITLE
Verbesserung Choices

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -333,6 +333,12 @@
   margin-bottom: 0;
 }
 
+@media (min-width: 640px) {
+    .choices__list--dropdown .choices__item--selectable:after {
+        content: none !important;
+    }
+}
+
 .text-larger {
   font-size: 1.2rem;
 }


### PR DESCRIPTION
Code entfernt den Text `Press to select` bei Choices (Bsp.: [Terminplan](https://icc.hgg-broich.de/appointments) -> Sidebar -> Abschnitt).

<img width="298" alt="Bildschirmfoto" src="https://user-images.githubusercontent.com/74987472/129492567-03e5b45e-9e03-4bec-b6ef-16db51817cca.png">
