### PR TITLE
Verbesserungsvorschlag: Callouts bei Export

### DIFF
--- a/templates/appointments/export.html.twig
+++ b/templates/appointments/export.html.twig
@@ -43,6 +43,7 @@
                 {{ form_end(form) }}
             {% else %}
                 <div class="bs-callout bs-callout-success">
+                    <h4>{{ 'plans.appointments.export.sync.success_head'|trans }}</h4>
                     <p>{{ 'plans.appointments.export.sync.success'|trans }}</p>
                 </div>
 

--- a/templates/appointments/export.html.twig
+++ b/templates/appointments/export.html.twig
@@ -15,7 +15,8 @@
         <div class="card-body">
             <h5 class="card-title">{{ 'plans.appointments.export.download.label'|trans }}</h5>
 
-            <div class="bs-callout bs-callout-danger">
+            <div class="bs-callout bs-callout-warning">
+                <h4>{{ 'plans.appointments.export.download.warning'|trans }}</h4>
                 <p>{{ 'plans.appointments.export.download.info'|trans }}</p>
             </div>
 

--- a/templates/exams/export.html.twig
+++ b/templates/exams/export.html.twig
@@ -16,7 +16,7 @@
             <h5 class="card-title">{{ 'plans.exams.export.download.label'|trans }}</h5>
 
             <div class="bs-callout bs-callout-warning">
-                <h4>{{ 'plans.appointments.export.download.warning'|trans }}</h4>
+                <h4>{{ 'plans.exams.export.download.warning'|trans }}</h4>
                 <p>{{ 'plans.exams.export.download.info'|trans }}</p>
             </div>
 
@@ -43,6 +43,7 @@
                 {{ form_end(form) }}
             {% else %}
                 <div class="bs-callout bs-callout-success">
+                    <h4>{{ 'plans.exams.export.sync.success_head'|trans }}</h4>
                     <p>{{ 'plans.exams.export.sync.success'|trans }}</p>
                 </div>
 

--- a/templates/exams/export.html.twig
+++ b/templates/exams/export.html.twig
@@ -15,7 +15,8 @@
         <div class="card-body">
             <h5 class="card-title">{{ 'plans.exams.export.download.label'|trans }}</h5>
 
-            <div class="bs-callout bs-callout-danger">
+            <div class="bs-callout bs-callout-warning">
+                <h4>{{ 'plans.appointments.export.download.warning'|trans }}</h4>
                 <p>{{ 'plans.exams.export.download.info'|trans }}</p>
             </div>
 

--- a/templates/timetable/export.html.twig
+++ b/templates/timetable/export.html.twig
@@ -16,7 +16,7 @@
             <h5 class="card-title">{{ 'plans.timetable.export.download.label'|trans }}</h5>
 
             <div class="bs-callout bs-callout-warning">
-                <h4>{{ 'plans.appointments.export.download.warning'|trans }}</h4>
+                <h4>{{ 'plans.timetable.export.download.warning'|trans }}</h4>
                 <p>{{ 'plans.timetable.export.download.info'|trans }}</p>
             </div>
 
@@ -43,6 +43,7 @@
                 {{ form_end(form) }}
             {% else %}
                 <div class="bs-callout bs-callout-success">
+                    <h4>{{ 'plans.timetable.export.sync.success_head'|trans }}</h4>
                     <p>{{ 'plans.timetable.export.sync.success'|trans }}</p>
                 </div>
 

--- a/templates/timetable/export.html.twig
+++ b/templates/timetable/export.html.twig
@@ -15,7 +15,8 @@
         <div class="card-body">
             <h5 class="card-title">{{ 'plans.timetable.export.download.label'|trans }}</h5>
 
-            <div class="bs-callout bs-callout-danger">
+            <div class="bs-callout bs-callout-warning">
+                <h4>{{ 'plans.appointments.export.download.warning'|trans }}</h4>
                 <p>{{ 'plans.timetable.export.download.info'|trans }}</p>
             </div>
 

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -295,6 +295,7 @@ plans:
             label: Klausuren exportieren
             download:
                 label: Einmaliger Download
+                warning: Achtung
                 info: Der Klausurplan wird bei dieser Methode nicht aktualisiert!
                 filename: klausuren.ics
             sync:
@@ -323,6 +324,7 @@ plans:
             description: 'Stundenplan von %name%'
             download:
                 label: Einmaliger Download
+                warning: Achtung
                 info: Der Stundenplan wird bei dieser Methode nicht aktualisiert!
                 filename: stundenplan.ics
             sync:
@@ -364,6 +366,7 @@ plans:
             label: Kalender exportieren
             download:
                 label: Einmaliger Download
+                warning: Achtung
                 info: Der Kalender wird bei dieser Methode nicht aktualisiert!
                 filename: termine.ics
             sync:

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -302,6 +302,7 @@ plans:
                 label: Link zur Synchronisation
                 info: Dieser Link kann in Diensten wie beispielsweise Outlook oder Google Kalender verwendet werden, der den Klausurplan damit aktuell hält.
                 name_help: Unter diesem Namen kann in den Profil-Einstellungen der Zugriff wieder entzogen werden.
+                success_head: Erfolg
                 success: Den folgenden Link nun in Outlook oder Google Kalender eintragen, um die Synchronisation zu beginnen.
 
     exam:
@@ -331,6 +332,7 @@ plans:
                 label: Link zur Synchronisation
                 info: Dieser Link kann in Diensten wie beispielsweise Outlook oder Google Kalender verwendet werden, der den Stundenplan damit aktuell hält.
                 name_help: Unter diesem Namen kann in den Profil-Einstellungen der Zugriff wieder entzogen werden.
+                success_head: Erfolg
                 success: Den folgenden Link nun in Outlook oder Google Kalender eintragen, um die Synchronisation zu beginnen.
         today: heute
         upcoming: demnächst
@@ -373,6 +375,7 @@ plans:
                 label: Link zur Synchronisation
                 info: Dieser Link kann in Diensten wie beispielsweise Outlook oder Google Kalender verwendet werden, der den Kalender damit aktuell hält.
                 name_help: Unter diesem Namen kann in den Profil-Einstellungen der Zugriff wieder entzogen werden.
+                success_head: Erfolg
                 success: Den folgenden Link nun in Outlook oder Google Kalender eintragen, um die Synchronisation zu beginnen.
             name: Schulkalender
             description: Export der Schulkalenders


### PR DESCRIPTION
Einheitliche Darstellung von callouts auf dem gesamten ICC.
Zudem lässt das callout beim einmaligen Download eher auf eine Fehlermeldung schließen. Dies sollte bei einer Warnung nicht der Fall sein.

# Ansicht

### ics Download

Vorher:
<img width="1412" alt="Bildschirmfoto 2021-08-19 um 12 47 22" src="https://user-images.githubusercontent.com/74987472/130090390-c9b06137-4948-4aea-a746-bf418ae27069.png">

Nachher:
<img width="1409" alt="Bildschirmfoto 2021-08-19 um 12 47 10" src="https://user-images.githubusercontent.com/74987472/130090373-78b799bf-5293-426c-adf0-14ebb7e2be92.png">

### Link

Vorher:
<img width="1413" alt="Bildschirmfoto 2021-08-19 um 12 47 49" src="https://user-images.githubusercontent.com/74987472/130090397-7952c30a-9114-435c-a3a1-1191b04d4441.png">

Nachher:
<img width="1422" alt="Bildschirmfoto 2021-08-19 um 12 52 23" src="https://user-images.githubusercontent.com/74987472/130090404-4ef0ada5-284a-4093-b220-a649fb47693d.png">
Update: Statt Erfolgreich wird nun Erfolg angezeigt.