### PR TITLE
Vorschlag: Icon Update Menü

### DIFF
--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -239,7 +239,7 @@ class Builder {
             ->setExtra('icon', 'fas fa-address-card');
 
         $label = 'dark_mode.enable';
-        $icon = 'far fa-moon';
+        $icon = 'fas fa-moon';
 
         if($this->darkModeManager->isDarkModeEnabled()) {
             $label = 'dark_mode.disable';

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -230,20 +230,20 @@ class Builder {
         $userMenu->addChild('profile.overview.label', [
             'route' => 'profile'
         ])
-            ->setExtra('icon', 'far fa-user');
+            ->setExtra('icon', 'fas fa-user');
 
         $userMenu->addChild('profile.label', [
             'uri' => $this->idpProfileUrl
         ])
             ->setLinkAttribute('target', '_blank')
-            ->setExtra('icon', 'far fa-address-card');
+            ->setExtra('icon', 'fas fa-address-card');
 
         $label = 'dark_mode.enable';
         $icon = 'far fa-moon';
 
         if($this->darkModeManager->isDarkModeEnabled()) {
             $label = 'dark_mode.disable';
-            $icon = 'far fa-sun';
+            $icon = 'fas fa-sun';
         }
 
         $userMenu->addChild($label, [
@@ -275,7 +275,7 @@ class Builder {
             $root->addChild('admin.documents.label', [
                 'route' => 'admin_documents'
             ])
-                ->setExtra('icon', 'far fa-file-alt');
+                ->setExtra('icon', 'fas fa-file-alt');
         }
 
         if($this->authorizationChecker->isGranted('ROLE_MESSAGE_CREATOR')) {
@@ -533,7 +533,7 @@ class Builder {
         $menu->addChild('documents.label', [
             'route' => 'documents'
         ])
-            ->setExtra('icon', 'far fa-file-alt');
+            ->setExtra('icon', 'fas fa-file-alt');
 
         $this->wikiMenu($menu);
 


### PR DESCRIPTION
# Idee
Um sich dem Stil der Icons im SC und SSO anzupassen, kann man das bei diesen Icons ebenfalls tun. 
Dies bietet sich ebenfalls an, da diese Icons u.a. bereits im SSO so dargestellt sind.

# Ansicht
Vorher:
<img width="112" alt="Bildschirmfoto 2021-09-27 um 08 30 39" src="https://user-images.githubusercontent.com/74987472/134976508-a45e73e2-03cc-4110-a012-7bb3704dcee8.png">
<img width="46" alt="Bildschirmfoto 2021-09-27 um 08 32 14" src="https://user-images.githubusercontent.com/74987472/134976509-bfe52e9c-24d2-41ca-9430-5323643aaa24.png">
<img width="44" alt="Bildschirmfoto 2021-09-27 um 08 32 31" src="https://user-images.githubusercontent.com/74987472/134976516-910a7c81-98d9-41ef-9a42-556249ab380e.png">
<img width="429" alt="Bildschirmfoto 2021-09-27 um 08 34 08" src="https://user-images.githubusercontent.com/74987472/134976524-fa90b1bd-c0b2-4bef-9770-c6bd35109793.png">

Nachher:
<img width="103" alt="Bildschirmfoto 2021-09-27 um 08 30 33" src="https://user-images.githubusercontent.com/74987472/134976502-ae51b216-ab2c-46ea-8986-841041138a37.png">
<img width="48" alt="Bildschirmfoto 2021-09-27 um 08 32 22" src="https://user-images.githubusercontent.com/74987472/134976513-a805450f-1426-4a46-9152-03e2b8dd910b.png">
<img width="50" alt="Bildschirmfoto 2021-09-27 um 08 32 39" src="https://user-images.githubusercontent.com/74987472/134976520-826bc063-c914-4f46-9e8c-8dde13843e9d.png">
<img width="432" alt="Bildschirmfoto 2021-09-27 um 08 34 00" src="https://user-images.githubusercontent.com/74987472/134976523-44da1830-047a-4ecd-8bcb-8c1a4710c0b6.png">
