### PR TITLE
Rechtschreibfehler/Vereinheitlichungen "Alte..."

### DIFF
--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -493,7 +493,7 @@ messages:
     overview:
         label: Mitteilungen
         empty: Aktuell gibt es keine Mitteilungen im System.
-        archive: alte Mitteilungen anzeigen
+        archive: Alte Mitteilungen anzeigen
         show_all: "Alle %num% Lerngruppen anzeigen"
     add:
         label: Neue Mitteilung


### PR DESCRIPTION
Hier wird die Checkbox "Alte … anzeigen" vereinheitlicht. Bis jetzt wurde "alte" mal klein, mal groß geschrieben.