### PR TITLE
Fix duplicated display of grade of teacher in teachers-list

### DIFF
--- a/templates/lists/teachers.html.twig
+++ b/templates/lists/teachers.html.twig
@@ -54,7 +54,7 @@
 
                                             </td>
                                             <td>
-                                                {% for gradeTeacher in teacher.grades %}
+                                                {% for gradeTeacher in teacher.grades|only_section(section) %}
                                                     {{ gradeTeacher.grade.name }}{% if gradeTeacher.type == 'substitute' %} <span title="{{ 'lists.teachers.substitute.long'|trans }}">{{ 'lists.teachers.substitute.short'|trans }}</span>{% endif %}{% if not loop.last %}, {% endif %}
                                                 {% endfor %}
                                             </td>


### PR DESCRIPTION
In der Lehrkräfte-Liste werden im zweiten Schulhalbjahr sowohl die Klassenlehrer\*innen und Stellvertreter\*innen des 1. als auch des 2. Halbjahres angezeigt. Das macht nicht viel Sinn, da so bei gleichbleibendem Klassenlehrer die Klasse zweimal aufgelistet wird oder bei einem Wechsel zwei verschiedene Lehrkräfte aufgelistet werden. Der Pull sollte das Problem lösen, indem er nur noch den Lehrer des aktuellen Halbjahres als Klassenlehrer\*in oder Stellvertreter\*in auflistet.

![image](https://user-images.githubusercontent.com/71940049/153712687-fd3defbf-a4d8-4b39-a153-f4527830f701.png)
