### PR TITLE
Anderes Icon für Import Widget

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -499,7 +499,7 @@
 
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title"><i class="fa fa-info-circle"></i> {{ 'label.last_import'|trans }}</h5>
+                        <h5 class="card-title"><i class="fa fa-file-import"></i> {{ 'label.last_import'|trans }}</h5>
                         <p>
                             {% if last_import is not null %}
                                 {{ last_import.updatedAt|format_datetime }}


### PR DESCRIPTION
## Vorher 
<img width="350" alt="Import1" src="https://user-images.githubusercontent.com/74987472/190149241-230430c4-9e64-4f72-9a87-b1d505479e4b.png">

## Nachher
<img width="344" alt="Import2" src="https://user-images.githubusercontent.com/74987472/190149252-a11d1dda-237d-402c-a5c1-63df65487e75.png">
