### PR TITLE
Maximale Breite für Bilder

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -483,3 +483,7 @@ table {
 .badge.freelesson {
   background-color: var(--bs-tertiary-color);
 }
+
+img, svg {
+  max-width: 100%;
+}


### PR DESCRIPTION
Im Wiki kann es bei großen Bilder dazu kommen, dass sie aus dem Inhaltsbereich heraus ragen.
![Bildschirmfoto 2023-08-10 um 11 16 10](https://github.com/SchulIT/icc/assets/74987472/17067176-d364-4cc4-8e4e-bdfedd4e279c)
Mit einer Maximalen Breite von 100% werden die Bilder wieder richtig eingefasst.
![Bildschirmfoto 2023-08-10 um 11 15 58](https://github.com/SchulIT/icc/assets/74987472/32b31a41-7c59-4941-8dda-295d7f32248d)

Habe es hier erstmal über das CSS gelöst. Aber eigentlich sollte der ImageProcessor vom Markdown das regeln:

`$node->data['attributes']['class'] = 'img-fluid mx-auto d-block';`

Vielleicht kann man auch da einen Bug lösen und sich das CSS sparen.
