### PR TITLE
Kalender ics Export Fehler bei Organisatoren

### DIFF
--- a/src/Export/AppointmentIcsExporter.php
+++ b/src/Export/AppointmentIcsExporter.php
@@ -99,7 +99,7 @@ class AppointmentIcsExporter {
             $description[] = $this->translator->trans('plans.appointments.export.category', ['%name%' => $appointment->getCategory()->getName() ]);
         }
 
-        if($appointment->getOrganizers()->count() > 0 || !empty($appointment->getExternalOrganizers())) {
+        /*if($appointment->getOrganizers()->count() > 0 || !empty($appointment->getExternalOrganizers())) {
             $organizers = $appointment->getOrganizers()->map(fn(Teacher $teacher) => $this->teacherConverter->convert($teacher))->toArray();
             $organizers[] = $appointment->getExternalOrganizers();
 
@@ -107,7 +107,7 @@ class AppointmentIcsExporter {
                 '%count%' => count($organizers),
                 '%name%' => implode(', ', $organizers)
             ]);
-        }
+        }*/
 
         return implode('\n', $description);
     }


### PR DESCRIPTION
nach runterladen der ics Datei und Import im Apple iCal, kam es dazu, dass eingetragene Organisatoren (in diesem Fall Herr Moss, der ja auch Apple Nutzer ist) als eingeladene Personen gewertet werden und eine Benachrichtigung bekommen.

Um das schnellstmöglich aufzuheben, würde ich vorschlagen die Organisatoren beim ics Export einfach rauszunehmen, um Fehler zu vermeiden.