### PR TITLE
Fix: Manuelles erstellen von Klassen mit Schülern nicht möglich

### DIFF
--- a/src/Entity/Grade.php
+++ b/src/Entity/Grade.php
@@ -31,7 +31,7 @@ class Grade implements Stringable {
     /**
      * @var ArrayCollection<GradeMembership>
      */
-    #[ORM\OneToMany(mappedBy: 'grade', targetEntity: GradeMembership::class)]
+    #[ORM\OneToMany(mappedBy: 'grade', targetEntity: GradeMembership::class, cascade: ['persist'])]
     private $memberships;
 
     /**

--- a/src/Entity/Grade.php
+++ b/src/Entity/Grade.php
@@ -72,7 +72,7 @@ class Grade implements Stringable {
         return $this;
     }
 
-    public function addMemebership(GradeMembership $membership): void {
+    public function addMembership(GradeMembership $membership): void {
         $membership->setGrade($this);
         $this->memberships->add($membership);
     }


### PR DESCRIPTION
Hi, ich hab mal wieder Zeit gefunden ein wenig rein zu schauen.
Beim manuellen erstellen von Klassen sind mir dabei einige Fehler on der Grade Entity geflogen. Einmal ist beim `addMemEbership` 

ein kleiner Typo, sodass Symfony die Funktion nicht findet. Hat man das gefixt, meckert Symfony, dass die Membership dann nicht mehr "Persitent" ist. ![Bildschirmfoto 2023-11-27 um 21 58 02](https://github.com/SchulIT/icc/assets/28061988/e5720c76-61ab-458b-8dfb-c0bd193a388f)