### PR TITLE
Temp Fix: Admin not able to view Dashboard

### DIFF
--- a/src/Dashboard/DashboardViewCollapseHelper.php
+++ b/src/Dashboard/DashboardViewCollapseHelper.php
@@ -17,7 +17,7 @@ class DashboardViewCollapseHelper {
     {
     }
 
-    public function collapseView(DashboardView $view, Teacher|Student $teacherOrStudent): void {
+    public function collapseView(DashboardView $view, Teacher|Student|null $teacherOrStudent): void {
         foreach($view->getLessons() as $lesson) {
             $this->collapseLesson($lesson, $view, $teacherOrStudent);
         }


### PR DESCRIPTION
Der erste in idp erstellte Admin kann sich zwar im icc einloggen, bekommt aber die folgenden Fehler-Meldung wenn das Dashboard geladen wird. Manuelles Aufrufen der Einstellungen über die `admin` URL ist trotzdem möglich.

![Bildschirmfoto 2023-11-27 um 22 16 44](https://github.com/SchulIT/icc/assets/28061988/f3d5d96a-e6da-4d8e-abcb-02203f786e23)

Das ist wahrscheinlich nur ein temporärer Fix und nix dauerhaftes.