### PR TITLE
Fix CodeMirror heading font size

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -534,3 +534,27 @@ table.sticky-header thead th {
   position: sticky;
   top: 0;
 }
+
+.cm-s-easymde .cm-header-1 {
+  font-size: 1.35rem
+}
+
+.cm-s-easymde .cm-header-2 {
+  font-size: 1.325rem
+}
+
+.cm-s-easymde .cm-header-3 {
+  font-size: 1.3rem
+}
+
+.cm-s-easymde .cm-header-4 {
+  font-size: 1.275rem
+}
+
+.cm-s-easymde .cm-header-5 {
+  font-size: 1.25rem
+}
+
+.cm-s-easymde .cm-header-6 {
+   font-size: 1rem
+}


### PR DESCRIPTION
# Vorher
<img width="1418" alt="Bildschirmfoto 2024-10-08 um 10 42 46" src="https://github.com/user-attachments/assets/4152db78-ee52-4eb9-8232-ba62fc70b07e">

# Nachher
<img width="1405" alt="Bildschirmfoto 2024-10-08 um 10 50 06" src="https://github.com/user-attachments/assets/29e155fe-7d86-49a8-92c3-26f59120e2fb">

Außerdem behebt sich damit ein Bearbeitungsfehler, der sonst durch die großen Überschriften den Kasten zu klein skaliert.
